### PR TITLE
feat(ENV-4346): update env var on deployment (+version)

### DIFF
--- a/charts/velocity-operator/Chart.yaml
+++ b/charts/velocity-operator/Chart.yaml
@@ -4,7 +4,7 @@ description: |-
   Spin up fully isolated, ephemeral environments in seconds.
   Develop code on your local machine and test it on a production-like environment.
 type: application
-version: 0.2.11
+version: 0.2.12
 
 # IMPORTANT: When upgrading the AWS ACK controller versions, make sure to update the `templates/crds` files
 # according to the new version CRDs.

--- a/charts/velocity-operator/templates/deployment.yaml
+++ b/charts/velocity-operator/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
             value: {{ quote .Values.controllerManager.manager.env.dryRun }}
           - name: CLOUD_RESOURCES_ENABLED
             value: {{ quote .Values.tags.cloudResources }}
+          - name: AWS_REGION
+            value: {{ .Values.aws.region }}
         readinessProbe:
           httpGet:
             path: /readyz

--- a/charts/velocity-operator/templates/deployment.yaml
+++ b/charts/velocity-operator/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
                 key: authToken
           - name: DRY_RUN
             value: {{ quote .Values.controllerManager.manager.env.dryRun }}
+          - name: CLOUD_RESOURCES_ENABLED
+            value: {{ quote .Values.tags.cloudResources }}
         readinessProbe:
           httpGet:
             path: /readyz


### PR DESCRIPTION
updating deployment to contain the env var indicating the cloud resources usage - `CLOUD_RESOURCES_ENABLED`.

ENV-4346

Note: 
This will propagate to the backend even without changes to the operator, since the operator is taking all the env vars that the process started with, and sending them as part of the "start info". 