### PR TITLE
chore: update operator image to v1.1.1

### DIFF
--- a/charts/velocity-operator/Chart.yaml
+++ b/charts/velocity-operator/Chart.yaml
@@ -4,7 +4,7 @@ description: |-
   Spin up fully isolated, ephemeral environments in seconds.
   Develop code on your local machine and test it on a production-like environment.
 type: application
-version: 0.2.18
+version: 0.2.19
 appVersion: v1.1.1
 # IMPORTANT: When upgrading the AWS ACK controller versions, make sure to update the `templates/crds` files
 # according to the new version CRDs.

--- a/charts/velocity-operator/Chart.yaml
+++ b/charts/velocity-operator/Chart.yaml
@@ -5,7 +5,7 @@ description: |-
   Develop code on your local machine and test it on a production-like environment.
 type: application
 version: 0.2.18
-appVersion: v0.0.7
+appVersion: v1.1.1
 # IMPORTANT: When upgrading the AWS ACK controller versions, make sure to update the `templates/crds` files
 # according to the new version CRDs.
 # The `fieldexports` and `adoptedresources` CRDs are defined under `templates/crds/aws`


### PR DESCRIPTION
This PR Addresses chore: update operator image to v1.1.1:
* chore(operator-release): update operator image for v1.1.1
