### PR TITLE
fix(ENV-4947): updating cluster role with the new verbs required to upgrade

### DIFF
--- a/charts/velocity-operator/Chart.yaml
+++ b/charts/velocity-operator/Chart.yaml
@@ -4,7 +4,7 @@ description: |-
   Spin up fully isolated, ephemeral environments in seconds.
   Develop code on your local machine and test it on a production-like environment.
 type: application
-version: 0.2.32
+version: 0.2.33
 appVersion: v1.6.1
 # IMPORTANT: When upgrading the AWS ACK controller versions, make sure to update the `templates/crds` files
 # according to the new version CRDs.

--- a/charts/velocity-operator/templates/proxy-rbac.yaml
+++ b/charts/velocity-operator/templates/proxy-rbac.yaml
@@ -11,12 +11,14 @@ rules:
   - tokenreviews
   verbs:
   - create
+  - get
 - apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
   verbs:
   - create
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
On upgrade we require to read the cluster role, so we need to add a GET verb.